### PR TITLE
Normalize YAML in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+---
 language: bash
-
 script:
-  - bin/fetch-configlet
-  - bin/configlet .
+- bin/fetch-configlet
+- bin/configlet .


### PR DESCRIPTION
The YAML was not quite valid. Travis can read it
and wasn't complaining, but this ensures that the YAML
is clean.
