### PR TITLE
Fix the last hamming test

### DIFF
--- a/exercises/hamming/hamming.tests.ps1
+++ b/exercises/hamming/hamming.tests.ps1
@@ -9,7 +9,7 @@ Describe "HammingTest" {
 	It "tests log identical strands" {
 		Compute "GGACTGA" "GGACTGA" | Should be 0
 	}
-	
+
 	It "tests complete distance in single nucleotide strands" {
 		Compute "A" "G" | Should be 1
 	}
@@ -37,7 +37,7 @@ Describe "HammingTest" {
 	It "tests non unique character in second strand" {
 		Compute "AGG" "AGA" | Should be 1
 	}
-	
+
 	It "tests same nucleotides in different position" {
 		Compute "TAG" "GAT" | Should be 2
 	}
@@ -45,7 +45,7 @@ Describe "HammingTest" {
 	It "tests large distance" {
 		Compute "GATACA" "GCATAA" | Should be 4
 	}
-	
+
 	It "tests large distance in off by one strand" {
 		Compute "GGACGGATTCTG" "AGGACGGATTCT" | Should be 9
 	}
@@ -59,6 +59,6 @@ Describe "HammingTest" {
 	}
 
 	It "tests disallow second strand longer" {
-		{ Compute("ATA", "AGTG") } | Should Throw "Mismatching string lengths"
+		{ Compute "ATA" "AGTG" } | Should Throw "Mismatching string lengths"
 	}
 }


### PR DESCRIPTION
I noticed that every test case except for the last one calls the `Compute` function like this:

```powershell
Compute "AAA" "BBB"
```

The last test case calls it like this:

```powershell
Compute("AAA", "BBB")
```

I'm new to Powershell, so I'm not 100% sure about this, but AFAICT, the first syntax is the correct, and the second syntax does something I don't understand.

For my implementation of the solution of this exercise, I get this error:

```
 [-] tests disallow second strand longer 33ms
   Expected: the expression to throw an exception with message {Mismatching string lengths}, an exception was raised, message was {You cannot call a method on a null-valued expression.}
       from /media/sf_Code/exercism/powershell/hamming/hamming.ps1:3 char:3
       +   $b = $args[1].ToCharArray()
       +   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
   at line: 62 in /media/sf_Code/exercism/powershell/hamming/hamming.tests.ps1
   62:          { Compute("ATA", "AGTG") } | Should Throw "Mismatching string lengths"

```

If I had to guess, I would say what's happening here is that we're passing in a single argument, the list `"ATA", "AGTG"` rather than the two arguments that the function `Compute` should expect.

This PR fixes the last test case so that it calls `Compute` with two arguments.