### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -48,13 +48,14 @@
       ]
     },
     {
-     "slug": "sum-of-multiples",
-     "uuid": "df4403d1-3fb2-4c2c-a228-2bdb442d0680",
+      "slug": "sum-of-multiples",
+      "uuid": "df4403d1-3fb2-4c2c-a228-2bdb442d0680",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "arrays",
+        "math",
         "transforming"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110