### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "0f9d8829-77a1-4ac0-af90-c0a99332f6fc",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing PowerShell locally",
+      "blurb": "Learn how to install PowerShell locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "ed1e5a2b-d95c-4f25-9010-b478e4a5e468",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn PowerShell",
+      "blurb": "An overview of how to get started from scratch with PowerShell"
+    },
+    {
+      "uuid": "0f3374ce-954c-4768-8114-56ea4aa8b3ef",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the PowerShell track",
+      "blurb": "Learn how to test your PowerShell exercises on Exercism"
+    },
+    {
+      "uuid": "1c0f8aaa-333f-48cd-a04f-ac132b4964f8",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful PowerShell resources",
+      "blurb": "A collection of useful resources to help you master PowerShell"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
