### PR TITLE
🤖 Add stub files to all exercises

### DIFF
--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -3,13 +3,13 @@
   "authors": [],
   "files": {
     "solution": [
-      "Bob.ps1"
+      "BobResponse.ps1"
     ],
     "test": [
-      "Bob.tests.ps1"
+      "BobResponse.tests.ps1"
     ],
     "example": [
-      "Bob.example.ps1"
+      "BobResponse.example.ps1"
     ]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -3,13 +3,13 @@
   "authors": [],
   "files": {
     "solution": [
-      "Hamming.ps1"
+      "HammingDifference.ps1"
     ],
     "test": [
-      "Hamming.tests.ps1"
+      "HammingDifference.tests.ps1"
     ],
     "example": [
-      "Hamming.example.ps1"
+      "HammingDifference.example.ps1"
     ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -3,13 +3,13 @@
   "authors": [],
   "files": {
     "solution": [
-      "Leap.ps1"
+      "LeapYear.ps1"
     ],
     "test": [
-      "Leap.tests.ps1"
+      "LeapYear.tests.ps1"
     ],
     "example": [
-      "Leap.example.ps1"
+      "LeapYear.example.ps1"
     ]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",


### PR DESCRIPTION
In this PR, we created (empty) stub files for all exercises that didn't yet have them.

The lack of stub file generates an unnecessary pain point within Exercism, contributing a significant proportion of support requests, making things more complex for our students, and hindering our ability to automatically run test-suites and provide automated analysis of solutions.

The original discussion for this is at exercism/discussions#238.

**We will automatically merge this PR in two week's time if it has not been merged by track maintainers at that point :slightly_smiling_face:**

## Tracking

https://github.com/exercism/v3-launch/issues/33
