### PR TITLE
[New Exercise]: Meet Up

### DIFF
--- a/config.json
+++ b/config.json
@@ -564,6 +564,14 @@
         "difficulty": 4
       },
       {
+        "slug": "meetup",
+        "name": "Meetup",
+        "uuid": "a5aff23f-7829-403f-843a-d3312dca31e8",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
         "slug": "queen-attack",
         "name": "Queen Attack",
         "uuid": "d116b6c3-9a79-4b03-9dbb-0499d9e6d112",

--- a/exercises/practice/meetup/.docs/instructions.md
+++ b/exercises/practice/meetup/.docs/instructions.md
@@ -1,0 +1,51 @@
+# Instructions
+
+Recurring monthly meetups are generally scheduled on the given weekday of a given week each month.
+In this exercise you will be given the recurring schedule, along with a month and year, and then asked to find the exact date of the meetup.
+
+For example a meetup might be scheduled on the _first Monday_ of every month.
+You might then be asked to find the date that this meetup will happen in January 2018.
+In other words, you need to determine the date of the first Monday of January 2018.
+
+Similarly, you might be asked to find:
+
+- the third Tuesday of August 2019 (August 20, 2019)
+- the teenth Wednesday of May 2020 (May 13, 2020)
+- the fourth Sunday of July 2021 (July 25, 2021)
+- the last Thursday of November 2022 (November 24, 2022)
+
+The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
+
+Note that descriptor `teenth` is a made-up word.
+
+It refers to the seven numbers that end in '-teen' in English: 13, 14, 15, 16, 17, 18, and 19.
+But general descriptions of dates use ordinal numbers, e.g. the _first_ Monday, the _third_ Tuesday.
+
+For the numbers ending in '-teen', that becomes:
+
+- 13th (thirteenth)
+- 14th (fourteenth)
+- 15th (fifteenth)
+- 16th (sixteenth)
+- 17th (seventeenth)
+- 18th (eighteenth)
+- 19th (nineteenth)
+
+So there are seven numbers ending in '-teen'.
+And there are also seven weekdays (Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday).
+Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teen" each month.
+
+If asked to find the teenth Saturday of August, 1953 (or, alternately the "Saturteenth" of August, 1953), we need to look at the calendar for August 1953:
+
+```plaintext
+    August 1953
+Su Mo Tu We Th Fr Sa
+                   1
+ 2  3  4  5  6  7  8
+ 9 10 11 12 13 14 15
+16 17 18 19 20 21 22
+23 24 25 26 27 28 29
+30 31
+```
+
+The Saturday that has a number ending in '-teen' is August 15, 1953.

--- a/exercises/practice/meetup/.meta/Meetup.example.ps1
+++ b/exercises/practice/meetup/.meta/Meetup.example.ps1
@@ -1,0 +1,52 @@
+Function Get-MeetUp {
+    <#
+    .SYNOPSIS
+    In this exercise you will be given the recurring schedule, along with a month and year, and then asked to find the exact date of the meetup.
+    
+    .DESCRIPTION
+    Given information for a meep up : year, month, weekday and schedule, return a datetime object of the meetup date.
+    
+    .PARAMETER Year
+    The year of the meetup date.
+
+    .PARAMETER Month
+    The month of the meetup date.
+
+    .PARAMETER Weekday
+    The weekday of the meetup date.
+
+    .PARAMETER Schedule
+    The position of the specified weekday within the month.
+    
+    .EXAMPLE
+    Get-MeetUp -Year 2002 -Month 12 -Weekday Monday -Schedule first
+    Return: Monday, December 2, 2002 00:00:00 
+
+    Note: 00:00:00 is just an example, Get-Date will return the current time (hour, min) based on your system unless you specify them.
+    #>
+    param(
+        [int]$year,
+        [ValidateRange(1,12)]
+        [int]$month,
+        [ValidateSet("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")]
+        [string]$weekday,
+        [ValidateSet("first", "second", "third", "fourth", "last", "teenth")]
+        [string]$schedule
+    )
+    $firstDay = Get-Date -Year $year -Month $month -Day 1
+
+    while ($firstDay.DayOfWeek -ne $weekday) {
+        $firstDay = $firstDay.AddDays(1)
+    }
+    $arrayOfDates = 0..4 | ForEach-Object {$firstDay.AddDays($_ * 7)} | Where-Object {$_.Month -eq $month}
+
+    $meetupDate = switch ($schedule) {
+        "first" { $arrayOfDates[0]  }
+        "second"{ $arrayOfDates[1]  }
+        "third" { $arrayOfDates[2]  }
+        "fourth"{ $arrayOfDates[3]  }
+        "last"  { $arrayOfDates[-1] }
+        Default { $arrayOfDates | Where-Object {$_.Day -ge 13 -and $_.Day -le 19} }
+    }
+    $meetupDate
+}

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": ["glaxxie"],
+  "files": {
+    "solution": [
+      "Meetup.ps1"
+    ],
+    "test": [
+      "Meetup.tests.ps1"
+    ],
+    "example": [
+      ".meta/Meetup.example.ps1"
+    ]
+  },
+  "blurb": "Calculate the date of meetups.",
+  "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
+  "source_url": "https://twitter.com/copiousfreetime"
+}

--- a/exercises/practice/meetup/.meta/tests.toml
+++ b/exercises/practice/meetup/.meta/tests.toml
@@ -1,0 +1,295 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8]
+description = "when teenth Monday is the 13th, the first day of the teenth week"
+
+[f78373d1-cd53-4a7f-9d37-e15bf8a456b4]
+description = "when teenth Monday is the 19th, the last day of the teenth week"
+
+[8c78bea7-a116-425b-9c6b-c9898266d92a]
+description = "when teenth Monday is some day in the middle of the teenth week"
+
+[cfef881b-9dc9-4d0b-8de4-82d0f39fc271]
+description = "when teenth Tuesday is the 19th, the last day of the teenth week"
+
+[69048961-3b00-41f9-97ee-eb6d83a8e92b]
+description = "when teenth Tuesday is some day in the middle of the teenth week"
+
+[d30bade8-3622-466a-b7be-587414e0caa6]
+description = "when teenth Tuesday is the 13th, the first day of the teenth week"
+
+[8db4b58b-92f3-4687-867b-82ee1a04f851]
+description = "when teenth Wednesday is some day in the middle of the teenth week"
+
+[6c27a2a2-28f8-487f-ae81-35d08c4664f7]
+description = "when teenth Wednesday is the 13th, the first day of the teenth week"
+
+[008a8674-1958-45b5-b8e6-c2c9960d973a]
+description = "when teenth Wednesday is the 19th, the last day of the teenth week"
+
+[e4abd5e3-57cb-4091-8420-d97e955c0dbd]
+description = "when teenth Thursday is some day in the middle of the teenth week"
+
+[85da0b0f-eace-4297-a6dd-63588d5055b4]
+description = "when teenth Thursday is the 13th, the first day of the teenth week"
+
+[ecf64f9b-8413-489b-bf6e-128045f70bcc]
+description = "when teenth Thursday is the 19th, the last day of the teenth week"
+
+[ac4e180c-7d0a-4d3d-b05f-f564ebb584ca]
+description = "when teenth Friday is the 19th, the last day of the teenth week"
+
+[b79101c7-83ad-4f8f-8ec8-591683296315]
+description = "when teenth Friday is some day in the middle of the teenth week"
+
+[6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8]
+description = "when teenth Friday is the 13th, the first day of the teenth week"
+
+[dfae03ed-9610-47de-a632-655ab01e1e7c]
+description = "when teenth Saturday is some day in the middle of the teenth week"
+
+[ec02e3e1-fc72-4a3c-872f-a53fa8ab358e]
+description = "when teenth Saturday is the 13th, the first day of the teenth week"
+
+[d983094b-7259-4195-b84e-5d09578c89d9]
+description = "when teenth Saturday is the 19th, the last day of the teenth week"
+
+[d84a2a2e-f745-443a-9368-30051be60c2e]
+description = "when teenth Sunday is the 19th, the last day of the teenth week"
+
+[0e64bc53-92a3-4f61-85b2-0b7168c7ce5a]
+description = "when teenth Sunday is some day in the middle of the teenth week"
+
+[de87652c-185e-4854-b3ae-04cf6150eead]
+description = "when teenth Sunday is the 13th, the first day of the teenth week"
+
+[2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411]
+description = "when first Monday is some day in the middle of the first week"
+
+[a6168c7c-ed95-4bb3-8f92-c72575fc64b0]
+description = "when first Monday is the 1st, the first day of the first week"
+
+[1bfc620f-1c54-4bbd-931f-4a1cd1036c20]
+description = "when first Tuesday is the 7th, the last day of the first week"
+
+[12959c10-7362-4ca0-a048-50cf1c06e3e2]
+description = "when first Tuesday is some day in the middle of the first week"
+
+[1033dc66-8d0b-48a1-90cb-270703d59d1d]
+description = "when first Wednesday is some day in the middle of the first week"
+
+[b89185b9-2f32-46f4-a602-de20b09058f6]
+description = "when first Wednesday is the 7th, the last day of the first week"
+
+[53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5]
+description = "when first Thursday is some day in the middle of the first week"
+
+[b420a7e3-a94c-4226-870a-9eb3a92647f0]
+description = "when first Thursday is another day in the middle of the first week"
+
+[61df3270-28b4-4713-bee2-566fa27302ca]
+description = "when first Friday is the 1st, the first day of the first week"
+
+[cad33d4d-595c-412f-85cf-3874c6e07abf]
+description = "when first Friday is some day in the middle of the first week"
+
+[a2869b52-5bba-44f0-a863-07bd1f67eadb]
+description = "when first Saturday is some day in the middle of the first week"
+
+[3585315a-d0db-4ea1-822e-0f22e2a645f5]
+description = "when first Saturday is another day in the middle of the first week"
+
+[c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1]
+description = "when first Sunday is some day in the middle of the first week"
+
+[1513328b-df53-4714-8677-df68c4f9366c]
+description = "when first Sunday is the 7th, the last day of the first week"
+
+[49e083af-47ec-4018-b807-62ef411efed7]
+description = "when second Monday is some day in the middle of the second week"
+
+[6cb79a73-38fe-4475-9101-9eec36cf79e5]
+description = "when second Monday is the 8th, the first day of the second week"
+
+[4c39b594-af7e-4445-aa03-bf4f8effd9a1]
+description = "when second Tuesday is the 14th, the last day of the second week"
+
+[41b32c34-2e39-40e3-b790-93539aaeb6dd]
+description = "when second Tuesday is some day in the middle of the second week"
+
+[90a160c5-b5d9-4831-927f-63a78b17843d]
+description = "when second Wednesday is some day in the middle of the second week"
+
+[23b98ce7-8dd5-41a1-9310-ef27209741cb]
+description = "when second Wednesday is the 14th, the last day of the second week"
+
+[447f1960-27ca-4729-bc3f-f36043f43ed0]
+description = "when second Thursday is some day in the middle of the second week"
+
+[c9aa2687-300c-4e79-86ca-077849a81bde]
+description = "when second Thursday is another day in the middle of the second week"
+
+[a7e11ef3-6625-4134-acda-3e7195421c09]
+description = "when second Friday is the 8th, the first day of the second week"
+
+[8b420e5f-9290-4106-b5ae-022f3e2a3e41]
+description = "when second Friday is some day in the middle of the second week"
+
+[80631afc-fc11-4546-8b5f-c12aaeb72b4f]
+description = "when second Saturday is some day in the middle of the second week"
+
+[e34d43ac-f470-44c2-aa5f-e97b78ecaf83]
+description = "when second Saturday is another day in the middle of the second week"
+
+[a57d59fd-1023-47ad-b0df-a6feb21b44fc]
+description = "when second Sunday is some day in the middle of the second week"
+
+[a829a8b0-abdd-4ad1-b66c-5560d843c91a]
+description = "when second Sunday is the 14th, the last day of the second week"
+
+[501a8a77-6038-4fc0-b74c-33634906c29d]
+description = "when third Monday is some day in the middle of the third week"
+
+[49e4516e-cf32-4a58-8bbc-494b7e851c92]
+description = "when third Monday is the 15th, the first day of the third week"
+
+[4db61095-f7c7-493c-85f1-9996ad3012c7]
+description = "when third Tuesday is the 21st, the last day of the third week"
+
+[714fc2e3-58d0-4b91-90fd-61eefd2892c0]
+description = "when third Tuesday is some day in the middle of the third week"
+
+[b08a051a-2c80-445b-9b0e-524171a166d1]
+description = "when third Wednesday is some day in the middle of the third week"
+
+[80bb9eff-3905-4c61-8dc9-bb03016d8ff8]
+description = "when third Wednesday is the 21st, the last day of the third week"
+
+[fa52a299-f77f-4784-b290-ba9189fbd9c9]
+description = "when third Thursday is some day in the middle of the third week"
+
+[f74b1bc6-cc5c-4bf1-ba69-c554a969eb38]
+description = "when third Thursday is another day in the middle of the third week"
+
+[8900f3b0-801a-466b-a866-f42d64667abd]
+description = "when third Friday is the 15th, the first day of the third week"
+
+[538ac405-a091-4314-9ccd-920c4e38e85e]
+description = "when third Friday is some day in the middle of the third week"
+
+[244db35c-2716-4fa0-88ce-afd58e5cf910]
+description = "when third Saturday is some day in the middle of the third week"
+
+[dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e]
+description = "when third Saturday is another day in the middle of the third week"
+
+[be71dcc6-00d2-4b53-a369-cbfae55b312f]
+description = "when third Sunday is some day in the middle of the third week"
+
+[b7d2da84-4290-4ee6-a618-ee124ae78be7]
+description = "when third Sunday is the 21st, the last day of the third week"
+
+[4276dc06-a1bd-4fc2-b6c2-625fee90bc88]
+description = "when fourth Monday is some day in the middle of the fourth week"
+
+[ddbd7976-2deb-4250-8a38-925ac1a8e9a2]
+description = "when fourth Monday is the 22nd, the first day of the fourth week"
+
+[eb714ef4-1656-47cc-913c-844dba4ebddd]
+description = "when fourth Tuesday is the 28th, the last day of the fourth week"
+
+[16648435-7937-4d2d-b118-c3e38fd084bd]
+description = "when fourth Tuesday is some day in the middle of the fourth week"
+
+[de062bdc-9484-437a-a8c5-5253c6f6785a]
+description = "when fourth Wednesday is some day in the middle of the fourth week"
+
+[c2ce6821-169c-4832-8d37-690ef5d9514a]
+description = "when fourth Wednesday is the 28th, the last day of the fourth week"
+
+[d462c631-2894-4391-a8e3-dbb98b7a7303]
+description = "when fourth Thursday is some day in the middle of the fourth week"
+
+[9ff1f7b6-1b72-427d-9ee9-82b5bb08b835]
+description = "when fourth Thursday is another day in the middle of the fourth week"
+
+[83bae8ba-1c49-49bc-b632-b7c7e1d7e35f]
+description = "when fourth Friday is the 22nd, the first day of the fourth week"
+
+[de752d2a-a95e-48d2-835b-93363dac3710]
+description = "when fourth Friday is some day in the middle of the fourth week"
+
+[eedd90ad-d581-45db-8312-4c6dcf9cf560]
+description = "when fourth Saturday is some day in the middle of the fourth week"
+
+[669fedcd-912e-48c7-a0a1-228b34af91d0]
+description = "when fourth Saturday is another day in the middle of the fourth week"
+
+[648e3849-ea49-44a5-a8a3-9f2a43b3bf1b]
+description = "when fourth Sunday is some day in the middle of the fourth week"
+
+[f81321b3-99ab-4db6-9267-69c5da5a7823]
+description = "when fourth Sunday is the 28th, the last day of the fourth week"
+
+[1af5e51f-5488-4548-aee8-11d7d4a730dc]
+description = "last Monday in a month with four Mondays"
+
+[f29999f2-235e-4ec7-9dab-26f137146526]
+description = "last Monday in a month with five Mondays"
+
+[31b097a0-508e-48ac-bf8a-f63cdcf6dc41]
+description = "last Tuesday in a month with four Tuesdays"
+
+[8c022150-0bb5-4a1f-80f9-88b2e2abcba4]
+description = "last Tuesday in another month with four Tuesdays"
+
+[0e762194-672a-4bdf-8a37-1e59fdacef12]
+description = "last Wednesday in a month with five Wednesdays"
+
+[5016386a-f24e-4bd7-b439-95358f491b66]
+description = "last Wednesday in a month with four Wednesdays"
+
+[12ead1a5-cdf9-4192-9a56-2229e93dd149]
+description = "last Thursday in a month with four Thursdays"
+
+[7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7]
+description = "last Thursday in a month with five Thursdays"
+
+[e47a739e-b979-460d-9c8a-75c35ca2290b]
+description = "last Friday in a month with five Fridays"
+
+[5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec]
+description = "last Friday in a month with four Fridays"
+
+[61e54cba-76f3-4772-a2b1-bf443fda2137]
+description = "last Saturday in a month with four Saturdays"
+
+[8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f]
+description = "last Saturday in another month with four Saturdays"
+
+[0b63e682-f429-4d19-9809-4a45bd0242dc]
+description = "last Sunday in a month with five Sundays"
+
+[5232307e-d3e3-4afc-8ba6-4084ad987c00]
+description = "last Sunday in a month with four Sundays"
+
+[0bbd48e8-9773-4e81-8e71-b9a51711e3c5]
+description = "when last Wednesday in February in a leap year is the 29th"
+
+[fe0936de-7eee-4a48-88dd-66c07ab1fefc]
+description = "last Wednesday in December that is also the last day of the year"
+
+[2ccf2488-aafc-4671-a24e-2b6effe1b0e2]
+description = "when last Sunday in February in a non-leap year is not the 29th"
+
+[00c3ce9f-cf36-4b70-90d8-92b32be6830e]
+description = "when first Friday is the 7th, the last day of the first week"

--- a/exercises/practice/meetup/Meetup.ps1
+++ b/exercises/practice/meetup/Meetup.ps1
@@ -1,0 +1,34 @@
+Function Get-MeetUp {
+    <#
+    .SYNOPSIS
+    In this exercise you will be given the recurring schedule, along with a month and year, and then asked to find the exact date of the meetup.
+    
+    .DESCRIPTION
+    Given information for a meep up : year, month, weekday and schedule, return a datetime object of the meetup date.
+    
+    .PARAMETER Year
+    The year of the meetup date.
+
+    .PARAMETER Month
+    The month of the meetup date.
+
+    .PARAMETER Weekday
+    The weekday of the meetup date.
+
+    .PARAMETER Schedule
+    The position of the specified weekday within the month.
+    
+    .EXAMPLE
+    Get-MeetUp -Year 2002 -Month 12 -Weekday Monday -Schedule first
+    Return: Monday, December 2, 2002 00:00:00 
+
+    Note: 00:00:00 is just an example, Get-Date will return the current time (hour, min) based on your system unless you specify them.
+    #>
+    param(
+        [int]$year,
+        [int]$month,
+        [string]$weekday,
+        [string]$schedule
+    )
+    Throw "Please implement this function"
+}

--- a/exercises/practice/meetup/Meetup.tests.ps1
+++ b/exercises/practice/meetup/Meetup.tests.ps1
@@ -1,0 +1,171 @@
+BeforeAll {
+    . "./Meetup.ps1"
+}
+
+Describe "Meetup test cases" {
+    Context "Monday tests" {
+        It "The <schedule> <weekday> of <month> in <year>" -TestCases @(
+            @{ year = 2013; month = 5; weekday = 'Monday'; schedule = 'teenth'; expect = '2013-05-13' }
+            @{ year = 2013; month = 8; weekday = 'Monday'; schedule = 'teenth'; expect = '2013-08-19' }
+            @{ year = 2013; month = 9; weekday = 'Monday'; schedule = 'teenth'; expect = '2013-09-16' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'first' ; expect = '2013-03-04' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'first' ; expect = '2013-04-01' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'second'; expect = '2013-03-11' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'second'; expect = '2013-04-08' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'third' ; expect = '2013-03-18' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'third' ; expect = '2013-04-15' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'fourth'; expect = '2013-03-25' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'fourth'; expect = '2013-04-22' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'last'  ; expect = '2013-03-25' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'last'  ; expect = '2013-04-29' }
+        ) { 
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Tuesday tests" {
+        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 3; weekday = 'Tuesday'; schedule = 'teenth'; expect = '2013-03-19' }
+            @{ year = 2013; month = 4; weekday = 'Tuesday'; schedule = 'teenth'; expect = '2013-04-16' }
+            @{ year = 2013; month = 8; weekday = 'Tuesday'; schedule = 'teenth'; expect = '2013-08-13' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'first' ; expect = '2013-05-07' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'first' ; expect = '2013-06-04' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'second'; expect = '2013-05-14' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'second'; expect = '2013-06-11' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'third' ; expect = '2013-05-21' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'third' ; expect = '2013-06-18' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'fourth'; expect = '2013-05-28' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'fourth'; expect = '2013-06-25' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'last'  ; expect = '2013-05-28' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'last'  ; expect = '2013-06-25' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Wednesday tests" {
+        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 1 ; weekday = 'Wednesday'; schedule = 'teenth'; expect = '2013-01-16' }
+            @{ year = 2013; month = 2 ; weekday = 'Wednesday'; schedule = 'teenth'; expect = '2013-02-13' }
+            @{ year = 2013; month = 6 ; weekday = 'Wednesday'; schedule = 'teenth'; expect = '2013-06-19' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'first' ; expect = '2013-07-03' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'first' ; expect = '2013-08-07' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'second'; expect = '2013-07-10' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'second'; expect = '2013-08-14' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'third' ; expect = '2013-07-17' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'third' ; expect = '2013-08-21' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'fourth'; expect = '2013-07-24' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'fourth'; expect = '2013-08-28' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'last'  ; expect = '2013-07-31' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'last'  ; expect = '2013-08-28' }
+            @{ year = 2012; month = 2 ; weekday = 'Wednesday'; schedule = 'last'  ; expect = '2012-02-29' }
+            @{ year = 2014; month = 12; weekday = 'Wednesday'; schedule = 'last'  ; expect = '2014-12-31' }
+
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Thursday tests" {
+        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 5 ; weekday = 'Thursday'; schedule = 'teenth'; expect = '2013-05-16' }
+            @{ year = 2013; month = 6 ; weekday = 'Thursday'; schedule = 'teenth'; expect = '2013-06-13' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'teenth'; expect = '2013-09-19' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'first' ; expect = '2013-09-05' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'first' ; expect = '2013-10-03' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'second'; expect = '2013-09-12' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'second'; expect = '2013-10-10' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'third' ; expect = '2013-09-19' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'third' ; expect = '2013-10-17' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'fourth'; expect = '2013-09-26' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'fourth'; expect = '2013-10-24' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'last'  ; expect = '2013-09-26' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'last'  ; expect = '2013-10-31' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Friday tests" {
+        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 4 ; weekday = 'Friday'; schedule = 'teenth'; expect = '2013-04-19' }
+            @{ year = 2013; month = 8 ; weekday = 'Friday'; schedule = 'teenth'; expect = '2013-08-16' }
+            @{ year = 2013; month = 9 ; weekday = 'Friday'; schedule = 'teenth'; expect = '2013-09-13' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'first' ; expect = '2013-11-01' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'first' ; expect = '2013-12-06' }
+            @{ year = 2012; month = 12; weekday = 'Friday'; schedule = 'first' ; expect = '2012-12-07' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'second'; expect = '2013-11-08' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'second'; expect = '2013-12-13' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'third' ; expect = '2013-11-15' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'third' ; expect = '2013-12-20' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'fourth'; expect = '2013-11-22' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'fourth'; expect = '2013-12-27' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'last'  ; expect = '2013-11-29' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'last'  ; expect = '2013-12-27' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Saturday tests" {
+        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'teenth'; expect = '2013-02-16' }
+            @{ year = 2013; month = 4 ; weekday = 'Saturday'; schedule = 'teenth'; expect = '2013-04-13' }
+            @{ year = 2013; month = 10; weekday = 'Saturday'; schedule = 'teenth'; expect = '2013-10-19' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'first' ; expect = '2013-01-05' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'first' ; expect = '2013-02-02' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'second'; expect = '2013-01-12' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'second'; expect = '2013-02-09' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'third' ; expect = '2013-01-19' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'third' ; expect = '2013-02-16' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'fourth'; expect = '2013-01-26' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'fourth'; expect = '2013-02-23' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'last'  ; expect = '2013-01-26' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'last'  ; expect = '2013-02-23' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Sunday tests" {
+        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 5 ; weekday = 'Sunday'; schedule = 'teenth'; expect = '2013-05-19' }
+            @{ year = 2013; month = 6 ; weekday = 'Sunday'; schedule = 'teenth'; expect = '2013-06-16' }
+            @{ year = 2013; month = 10; weekday = 'Sunday'; schedule = 'teenth'; expect = '2013-10-13' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'first' ; expect = '2013-03-03' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'first' ; expect = '2013-04-07' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'second'; expect = '2013-03-10' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'second'; expect = '2013-04-14' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'third' ; expect = '2013-03-17' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'third' ; expect = '2013-04-21' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'fourth'; expect = '2013-03-24' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'fourth'; expect = '2013-04-28' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'last'  ; expect = '2013-03-31' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'last'  ; expect = '2013-04-28' }
+            @{ year = 2015; month = 2 ; weekday = 'Sunday'; schedule = 'last'  ; expect = '2015-02-22' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+}

--- a/exercises/practice/meetup/Meetup.tests.ps1
+++ b/exercises/practice/meetup/Meetup.tests.ps1
@@ -4,7 +4,7 @@ BeforeAll {
 
 Describe "Meetup test cases" {
     Context "Monday tests" {
-        It "The <schedule> <weekday> of <month> in <year>" -TestCases @(
+        It "The <schedule> <weekday> of month <month> in <year>" -TestCases @(
             @{ year = 2013; month = 5; weekday = 'Monday'; schedule = 'teenth'; expect = '2013-05-13' }
             @{ year = 2013; month = 8; weekday = 'Monday'; schedule = 'teenth'; expect = '2013-08-19' }
             @{ year = 2013; month = 9; weekday = 'Monday'; schedule = 'teenth'; expect = '2013-09-16' }
@@ -27,7 +27,7 @@ Describe "Meetup test cases" {
     }
 
     Context "Tuesday tests" {
-        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
             @{ year = 2013; month = 3; weekday = 'Tuesday'; schedule = 'teenth'; expect = '2013-03-19' }
             @{ year = 2013; month = 4; weekday = 'Tuesday'; schedule = 'teenth'; expect = '2013-04-16' }
             @{ year = 2013; month = 8; weekday = 'Tuesday'; schedule = 'teenth'; expect = '2013-08-13' }
@@ -50,7 +50,7 @@ Describe "Meetup test cases" {
     }
 
     Context "Wednesday tests" {
-        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
             @{ year = 2013; month = 1 ; weekday = 'Wednesday'; schedule = 'teenth'; expect = '2013-01-16' }
             @{ year = 2013; month = 2 ; weekday = 'Wednesday'; schedule = 'teenth'; expect = '2013-02-13' }
             @{ year = 2013; month = 6 ; weekday = 'Wednesday'; schedule = 'teenth'; expect = '2013-06-19' }
@@ -76,7 +76,7 @@ Describe "Meetup test cases" {
     }
 
     Context "Thursday tests" {
-        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
             @{ year = 2013; month = 5 ; weekday = 'Thursday'; schedule = 'teenth'; expect = '2013-05-16' }
             @{ year = 2013; month = 6 ; weekday = 'Thursday'; schedule = 'teenth'; expect = '2013-06-13' }
             @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'teenth'; expect = '2013-09-19' }
@@ -99,7 +99,7 @@ Describe "Meetup test cases" {
     }
 
     Context "Friday tests" {
-        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
             @{ year = 2013; month = 4 ; weekday = 'Friday'; schedule = 'teenth'; expect = '2013-04-19' }
             @{ year = 2013; month = 8 ; weekday = 'Friday'; schedule = 'teenth'; expect = '2013-08-16' }
             @{ year = 2013; month = 9 ; weekday = 'Friday'; schedule = 'teenth'; expect = '2013-09-13' }
@@ -123,7 +123,7 @@ Describe "Meetup test cases" {
     }
 
     Context "Saturday tests" {
-        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
             @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'teenth'; expect = '2013-02-16' }
             @{ year = 2013; month = 4 ; weekday = 'Saturday'; schedule = 'teenth'; expect = '2013-04-13' }
             @{ year = 2013; month = 10; weekday = 'Saturday'; schedule = 'teenth'; expect = '2013-10-19' }
@@ -146,7 +146,7 @@ Describe "Meetup test cases" {
     }
 
     Context "Sunday tests" {
-        It "The <schedule> <weekday> of <month> in <year>" -ForEach @(
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
             @{ year = 2013; month = 5 ; weekday = 'Sunday'; schedule = 'teenth'; expect = '2013-05-19' }
             @{ year = 2013; month = 6 ; weekday = 'Sunday'; schedule = 'teenth'; expect = '2013-06-16' }
             @{ year = 2013; month = 10; weekday = 'Sunday'; schedule = 'teenth'; expect = '2013-10-13' }


### PR DESCRIPTION
Since this exercise use quite a number of test cases (95 based on pester) with only some minor differences, I streamlined them into groups and using array of testcases. The test names, particular the month is less descriptive, it will be number instead of word, e.g 5 instead of May.  I tried a couple ways to expand variable and conversion to have more dynamic month name but got no luck with it. I also have a backup classic style of tests if you prefer that one.
