### PR TITLE
[New Exercise]: Resistor Color Trio

### DIFF
--- a/config.json
+++ b/config.json
@@ -130,6 +130,16 @@
         "difficulty": 1
       },
       {
+        "slug": "resistor-color-trio",
+        "name": "Resistor Color Trio",
+        "uuid": "666f7921-e650-4c6d-9f4c-f9a653c33a1d",
+        "practices": [
+            "strings"
+        ],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
         "slug": "raindrops",
         "name": "Raindrops",
         "uuid": "90a12652-946c-4771-83bd-741f884cd426",

--- a/exercises/practice/resistor-color-trio/.docs/instructions.md
+++ b/exercises/practice/resistor-color-trio/.docs/instructions.md
@@ -1,0 +1,56 @@
+# Instructions
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know only three things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+  To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+- Each band acts as a digit of a number.
+  For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands.
+  The program will take 3 colors as input, and outputs the correct value, in ohms.
+  The color bands are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+In Resistor Color Duo you decoded the first two colors.
+For instance: orange-orange got the main value `33`.
+The third color stands for how many zeros need to be added to the main value.
+The main value plus the zeros gives us a value in ohms.
+For the exercise it doesn't matter what ohms really are.
+For example:
+
+- orange-orange-black would be 33 and no zeros, which becomes 33 ohms.
+- orange-orange-red would be 33 and 2 zeros, which becomes 3300 ohms.
+- orange-orange-orange would be 33 and 3 zeros, which becomes 33000 ohms.
+
+(If Math is your thing, you may want to think of the zeros as exponents of 10.
+If Math is not your thing, go with the zeros.
+It really is the same thing, just in plain English instead of Math lingo.)
+
+This exercise is about translating the colors into a label:
+
+> "... ohms"
+
+So an input of `"orange", "orange", "black"` should return:
+
+> "33 ohms"
+
+When we get to larger resistors, a [metric prefix][metric-prefix] is used to indicate a larger magnitude of ohms, such as "kiloohms".
+That is similar to saying "2 kilometers" instead of "2000 meters", or "2 kilograms" for "2000 grams".
+
+For example, an input of `"orange", "orange", "orange"` should return:
+
+> "33 kiloohms"
+
+[metric-prefix]: https://en.wikipedia.org/wiki/Metric_prefix

--- a/exercises/practice/resistor-color-trio/.meta/ResistorColorTrio.example.ps1
+++ b/exercises/practice/resistor-color-trio/.meta/ResistorColorTrio.example.ps1
@@ -1,0 +1,49 @@
+Function Get-ResistorLabel() {
+    <#
+    .SYNOPSIS
+    Implement a function to get the label of a resistor with three color-coded bands.
+
+    .DESCRIPTION
+    Given an array of colors from a resistor, decode their resistance values and return a string represent the resistor's label.
+
+    .PARAMETER Colors
+    The array repesent the 3 colors from left to right.
+
+    .EXAMPLE
+    Get-ResistorLabel -Colors @("red", "white", "blue")
+    Return: "29 megaohms"
+     #>
+    [CmdletBinding()]
+    Param(
+        [string[]]$Colors
+    )
+    $colorsCode = @{
+        "black"  = 0
+        "brown"  = 1
+        "red"    = 2
+        "orange" = 3
+        "yellow" = 4
+        "green"  = 5
+        "blue"   = 6
+        "violet" = 7
+        "grey"   = 8
+        "white"  = 9
+    }
+
+    $units = [ordered]@{
+        1e9 = "gigaohms"
+        1e6 = "megaohms"
+        1e3 = "kiloohms"
+    }
+
+    $baseValue  = $colorsCode[$Colors[0]] * 10 + $colorsCode[$Colors[1]]
+    $magnitute  = [Math]::Pow(10, $colorsCode[$Colors[2]])
+    $total      = $baseValue * $magnitute
+
+    foreach ($key in $units.Keys) {
+        if ($total -gt $key) {
+            return "$($total / $key) $($units[$key])"
+        }
+    }
+    return "$total ohms"
+}

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "glaxxie"
+  ],
+  "files": {
+    "solution": [
+      "ResistorColorTrio.ps1"
+    ],
+    "test": [
+      "ResistorColorTrio.tests.ps1"
+    ],
+    "example": [
+      ".meta/ResistorColorTrio.example.ps1"
+    ]
+  },
+  "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
+  "source": "Maud de Vries, Erik Schierboom",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1549"
+}

--- a/exercises/practice/resistor-color-trio/.meta/tests.toml
+++ b/exercises/practice/resistor-color-trio/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[d6863355-15b7-40bb-abe0-bfb1a25512ed]
+description = "Orange and orange and black"
+
+[1224a3a9-8c8e-4032-843a-5224e04647d6]
+description = "Blue and grey and brown"
+
+[b8bda7dc-6b95-4539-abb2-2ad51d66a207]
+description = "Red and black and red"
+
+[5b1e74bc-d838-4eda-bbb3-eaba988e733b]
+description = "Green and brown and orange"
+
+[f5d37ef9-1919-4719-a90d-a33c5a6934c9]
+description = "Yellow and violet and yellow"
+
+[5f6404a7-5bb3-4283-877d-3d39bcc33854]
+description = "Blue and violet and blue"
+
+[7d3a6ab8-e40e-46c3-98b1-91639fff2344]
+description = "Minimum possible value"
+
+[ca0aa0ac-3825-42de-9f07-dac68cc580fd]
+description = "Maximum possible value"
+
+[0061a76c-903a-4714-8ce2-f26ce23b0e09]
+description = "First two colors make an invalid octal number"
+
+[30872c92-f567-4b69-a105-8455611c10c4]
+description = "Ignore extra colors"

--- a/exercises/practice/resistor-color-trio/ResistorColorTrio.ps1
+++ b/exercises/practice/resistor-color-trio/ResistorColorTrio.ps1
@@ -1,0 +1,21 @@
+Function Get-ResistorLabel() {
+    <#
+    .SYNOPSIS
+    Implement a function to get the label of a resistor with three color-coded bands.
+
+    .DESCRIPTION
+    Given an array of colors from a resistor, decode their resistance values and return a string represent the resistor's label.
+
+    .PARAMETER Colors
+    The array repesent the 3 colors from left to right.
+
+    .EXAMPLE
+    Get-ResistorLabel -Colors @("red", "white", "blue")
+    Return: "29 megaohms"
+     #>
+    [CmdletBinding()]
+    Param(
+        [string[]]$Colors
+    )
+    Throw "Please implement this function"
+}

--- a/exercises/practice/resistor-color-trio/ResistorColorTrio.tests.ps1
+++ b/exercises/practice/resistor-color-trio/ResistorColorTrio.tests.ps1
@@ -1,0 +1,76 @@
+BeforeAll {
+    . "./ResistorColorTrio.ps1"
+}
+
+Describe "ResistorColorTrio test cases" {
+    It "Orange and orange and black" {
+        $got  = Get-ResistorLabel -Colors @("orange", "orange", "black")
+        $want = "33 ohms" 
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Blue and grey and brown" {
+        $got  = Get-ResistorLabel -Colors @("blue", "grey", "brown")
+        $want = "680 ohms" 
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Red and black and red" {
+        $got  = Get-ResistorLabel -Colors @("red", "black", "red")
+        $want = "2 kiloohms"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Green and brown and orange" {
+        $got  = Get-ResistorLabel -Colors @("green", "brown", "orange")
+        $want = "51 kiloohms"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Yellow and violet and yellow" {
+        $got  = Get-ResistorLabel -Colors @("yellow", "violet", "yellow")
+        $want = "470 kiloohms"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Blue and violet and blue" {
+        $got  = Get-ResistorLabel -Colors @("blue", "violet", "blue")
+        $want = "67 megaohms"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Minimum possible value" {
+        $got  = Get-ResistorLabel -Colors @("black", "black", "black")
+        $want = "0 ohms"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Maximum possible value" {
+        $got  = Get-ResistorLabel -Colors @("white", "white", "white")
+        $want = "99 gigaohms"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "First two colors make an invalid octal number" {
+        $got  = Get-ResistorLabel -Colors @("black", "grey", "black")
+        $want = "8 ohms"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Ignore extra colors" {
+        $got  = Get-ResistorLabel -Colors @("blue", "green", "yellow", "orange")
+        $want = "650 kiloohms"
+
+        $got | Should -BeExactly $want
+    }
+
+}


### PR DESCRIPTION
I also want to create Resistor Color Expert, but I didn't see it on the list for "unimplemented practice exercise".
IIrc this exercise was added relatively recently to other tracks (2 months ago on python) so maybe the data hasnt been updated yet to sync?