### PR TITLE
Change keyword names to Pascal case for 'Hello World' exercise

### DIFF
--- a/exercises/practice/hello-world/HelloWorld.ps1
+++ b/exercises/practice/hello-world/HelloWorld.ps1
@@ -1,4 +1,4 @@
-function Get-HelloWorld {
+Function Get-HelloWorld {
     <#
     .SYNOPSIS
     Outputs "Hello, World!"
@@ -10,5 +10,5 @@ function Get-HelloWorld {
     Get-HelloWorld
     #>	
     
-    return "Goodbye, Mars!"
+    Return "Goodbye, Mars!"
 }


### PR DESCRIPTION
Overall, within exercises the `function` keyword is written in Pascal case (`Function`) within this repository, it seems.
This aligns the `Hello World` exercise to that convention, plus changes `return` to `Return` in line with that as well.