### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/exercises/practice/rational-numbers/.docs/instructions.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.md
@@ -2,11 +2,11 @@
 
 A rational number is defined as the quotient of two integers `a` and `b`, called the numerator and denominator, respectively, where `b != 0`.
 
-```exercism/note
+~~~~exercism/note
 Note that mathematically, the denominator can't be zero.
 However in many implementations of rational numbers, you will find that the denominator is allowed to be zero with behaviour similar to positive or negative infinity in floating point numbers.
 In those cases, the denominator and numerator generally still can't both be zero at once.
-```
+~~~~
 
 The absolute value `|r|` of the rational number `r = a/b` is equal to `|a|/|b|`.
 


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705