### PR TITLE
update meta info and test case

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -19,5 +19,5 @@
   },
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "source": "Conversation with James Edward Gray II",
-  "source_url": "https://twitter.com/jeg2"
+  "source_url": "http://graysoftinc.com/"
 }

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -46,6 +46,11 @@ description = "detects anagrams using case-insensitive possible matches"
 
 [7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
 description = "does not detect an anagram if the original word is repeated"
+include = false
+
+[630abb71-a94e-4715-8395-179ec1df9f91]
+description = "does not detect an anagram if the original word is repeated"
+reimplements = "7cc195ad-e3c7-44ee-9fd2-d3c344806a2c"
 
 [9878a1c9-d6ea-4235-ae51-3ea2befd6842]
 description = "anagrams must use all letters exactly once"

--- a/exercises/practice/anagram/Anagram.tests.ps1
+++ b/exercises/practice/anagram/Anagram.tests.ps1
@@ -74,7 +74,7 @@ Describe "Test Invoke-Anagram.ps1" {
     }
 
     It "does not detect a anagram if the original word is repeated" {
-        $got = Invoke-Anagram -Subject "go" -Candidates @("go Go GO")
+        $got = Invoke-Anagram -Subject "go" -Candidates @("goGoGO")
         $want = @()
 
         $got | Should -Be $want

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -14,6 +14,5 @@
     ]
   },
   "blurb": "Insert and search for numbers in a binary tree.",
-  "source": "Josh Cheek",
-  "source_url": "https://twitter.com/josh_cheek"
+  "source": "Josh Cheek"
 }

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,5 +1,7 @@
 {
-  "authors": ["glaxxie"],
+  "authors": [
+    "glaxxie"
+  ],
   "files": {
     "solution": [
       "Clock.ps1"
@@ -12,6 +14,5 @@
     ]
   },
   "blurb": "Implement a clock that handles times without dates.",
-  "source": "Pairing session with Erin Drummond",
-  "source_url": "https://twitter.com/ebdrummond"
+  "source": "Pairing session with Erin Drummond"
 }

--- a/exercises/practice/custom-set/.meta/tests.toml
+++ b/exercises/practice/custom-set/.meta/tests.toml
@@ -75,6 +75,9 @@ description = "Sets with the same elements are equal -> sets with different elem
 [06059caf-9bf4-425e-aaff-88966cb3ea14]
 description = "Sets with the same elements are equal -> set is not equal to larger set with same elements"
 
+[d4a1142f-09aa-4df9-8b83-4437dcf7ec24]
+description = "Sets with the same elements are equal -> set is equal to a set constructed from an array with duplicates"
+
 [8a677c3c-a658-4d39-bb88-5b5b1a9659f4]
 description = "Unique elements can be added to a set -> add to empty set"
 

--- a/exercises/practice/custom-set/CustomSet.tests.ps1
+++ b/exercises/practice/custom-set/CustomSet.tests.ps1
@@ -184,6 +184,14 @@ Describe "custom set test cases" {
 
             $got | Should -BeFalse
         }
+
+        It "equality ->  set is equal to a set constructed from an array with duplicates" {
+            $set1 = [CustomSet]::new(@(1))
+            $set2 = [CustomSet]::new(@(1, 1))
+            $got  = $set1 -eq $set2
+
+            $got | Should -BeFalse
+        }
     }
 
     Context "operation methods" {

--- a/exercises/practice/dnd-character/.meta/tests.toml
+++ b/exercises/practice/dnd-character/.meta/tests.toml
@@ -65,3 +65,8 @@ description = "random character is valid"
 
 [2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe]
 description = "each ability is only calculated once"
+include = false
+
+[dca2b2ec-f729-4551-84b9-078876bb4808]
+description = "each ability is only calculated once"
+reimplements = "2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe"

--- a/exercises/practice/dnd-character/DndCharacter.tests.ps1
+++ b/exercises/practice/dnd-character/DndCharacter.tests.ps1
@@ -146,10 +146,13 @@ Describe "DnD Character test cases" {
 
         It "each ability is calculated once" {
             $character = [Character]::New()
-            $got  = $character.Charisma
-            $want = $character.Charisma
 
-            $got | Should -BeExactly $want
+            $character.Strength     | Should -BeExactly $character.Strength
+            $character.Dexterity    | Should -BeExactly $character.Dexterity
+            $character.Constitution | Should -BeExactly $character.Constitution
+            $character.Intelligence | Should -BeExactly $character.Intelligence
+            $character.Wisdom       | Should -BeExactly $character.Wisdom
+            $character.Charisma     | Should -BeExactly $character.Charisma
         }
     }
 }

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -27,11 +27,17 @@ description = "returns the number of grains on the square -> grains on square 16
 [acd81b46-c2ad-4951-b848-80d15ed5a04f]
 description = "returns the number of grains on the square -> grains on square 32"
 
+[c73b470a-5efb-4d53-9ac6-c5f6487f227b]
+description = "returns the number of grains on the square -> grains on square 64"
+
 [1d47d832-3e85-4974-9466-5bd35af484e3]
-description = "returns the number of grains on the square -> square 0 raises an exception"
+description = "returns the number of grains on the square -> square 0 is invalid"
 
 [61974483-eeb2-465e-be54-ca5dde366453]
-description = "returns the number of grains on the square -> negative square raises an exception"
+description = "returns the number of grains on the square -> negative square is invalid"
 
 [a95e4374-f32c-45a7-a10d-ffec475c012f]
-description = "returns the number of grains on the square -> square greater than 64 raises an exception"
+description = "returns the number of grains on the square -> square greater than 64 is invalid"
+
+[6eb07385-3659-4b45-a6be-9dc474222750]
+description = "returns the total number of grains on the board"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -20,7 +20,7 @@
       ".meta/HelloWorld.example.ps1"
     ]
   },
-  "blurb": "The classical introductory exercise. Just say \"Hello, World!\".",
+  "blurb": "Exercism's classic introductory exercise. Just say \"Hello, World!\".",
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "https://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
 }

--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -9,6 +9,9 @@
 # As user-added comments (using the # character) will be removed when this file
 # is regenerated, comments can be added via a `comment` key.
 
+[0caa3eac-d2e3-4c29-8df8-b188bc8c9292]
+description = "valid isbn"
+
 [19f76b53-7c24-45f8-87b8-4604d0ccd248]
 description = "invalid isbn check digit"
 

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -47,3 +47,6 @@ description = "duplicated character in the middle"
 
 [310ac53d-8932-47bc-bbb4-b2b94f25a83e]
 description = "same first and last characters"
+
+[0d0b8644-0a1e-4a31-a432-2b3ee270d847]
+description = "word with duplicated character and with two hyphens"

--- a/exercises/practice/knapsack/.meta/tests.toml
+++ b/exercises/practice/knapsack/.meta/tests.toml
@@ -11,6 +11,11 @@
 
 [a4d7d2f0-ad8a-460c-86f3-88ba709d41a7]
 description = "no items"
+include = false
+
+[3993a824-c20e-493d-b3c9-ee8a7753ee59]
+description = "no items"
+reimplements = "a4d7d2f0-ad8a-460c-86f3-88ba709d41a7"
 
 [1d39e98c-6249-4a8b-912f-87cb12e506b0]
 description = "one item, too heavy"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -18,7 +18,7 @@
       ".meta/LeapYear.example.ps1"
     ]
   },
-  "blurb": "Given a year, report if it is a leap year.",
+  "blurb": "Determine whether a given year is a leap year.",
   "source": "CodeRanch Cattle Drive, Assignment 3",
   "source_url": "https://coderanch.com/t/718816/Leap"
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,5 +1,7 @@
 {
-  "authors": ["glaxxie"],
+  "authors": [
+    "glaxxie"
+  ],
   "files": {
     "solution": [
       "Meetup.ps1"
@@ -13,5 +15,5 @@
   },
   "blurb": "Calculate the date of meetups.",
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
-  "source_url": "https://twitter.com/copiousfreetime"
+  "source_url": "http://www.copiousfreetime.org/"
 }

--- a/exercises/practice/poker/.meta/tests.toml
+++ b/exercises/practice/poker/.meta/tests.toml
@@ -21,11 +21,17 @@ description = "a tie has multiple winners"
 [61ed83a9-cfaa-40a5-942a-51f52f0a8725]
 description = "multiple hands with the same high cards, tie compares next highest ranked, down to last card"
 
+[da01becd-f5b0-4342-b7f3-1318191d0580]
+description = "winning high card hand also has the lowest card"
+
 [f7175a89-34ff-44de-b3d7-f6fd97d1fca4]
 description = "one pair beats high card"
 
 [e114fd41-a301-4111-a9e7-5a7f72a76561]
 description = "highest pair wins"
+
+[b3acd3a7-f9fa-4647-85ab-e0a9e07d1365]
+description = "both hands have the same pair, high card wins"
 
 [935bb4dc-a622-4400-97fa-86e7d06b1f76]
 description = "two pairs beats one pair"
@@ -53,6 +59,11 @@ description = "both hands have three of a kind, tie goes to highest ranked tripl
 
 [eb856cc2-481c-4b0d-9835-4d75d07a5d9d]
 description = "with multiple decks, two players can have same three of a kind, ties go to highest remaining cards"
+include = false
+
+[26a4a7d4-34a2-4f18-90b4-4a8dd35d2bb1]
+description = "with multiple decks, two players can have same three of a kind, ties go to highest remaining cards"
+reimplements = "eb856cc2-481c-4b0d-9835-4d75d07a5d9d"
 
 [a858c5d9-2f28-48e7-9980-b7fa04060a60]
 description = "a straight beats three of a kind"
@@ -77,6 +88,11 @@ description = "flush beats a straight"
 
 [4d90261d-251c-49bd-a468-896bf10133de]
 description = "both hands have a flush, tie goes to high card, down to the last one if necessary"
+include = false
+
+[e04137c5-c19a-4dfc-97a1-9dfe9baaa2ff]
+description = "both hands have a flush, tie goes to high card, down to the last one if necessary"
+reimplements = "4d90261d-251c-49bd-a468-896bf10133de"
 
 [3a19361d-8974-455c-82e5-f7152f5dba7c]
 description = "full house beats a flush"

--- a/exercises/practice/poker/Poker.tests.ps1
+++ b/exercises/practice/poker/Poker.tests.ps1
@@ -130,7 +130,7 @@ Describe "Poker test cases" {
 
     It "with multiple decks, two players can have the same three of a kind, ties go to highest remaining cards" {
         $got  = Get-BestHand -Hands @(
-            "4S AH AS 7C AD",
+            "5S AH AS 7C AD",
             "4S AH AS 8C AD")
         $want = @("4S AH AS 8C AD")
     
@@ -202,9 +202,9 @@ Describe "Poker test cases" {
     
     It "both hands have a flush, tie goes to the high card, down to the last one if necessary" {
         $got  = Get-BestHand -Hands @(
-            "4H 7H 8H 9H 6H",
-            "2S 4S 5S 6S 7S")
-        $want = @("4H 7H 8H 9H 6H")
+            "2H 7H 8H 9H 6H",
+            "3S 5S 6S 7S 8S")
+        $want = @("2H 7H 8H 9H 6H")
     
         $got | Should -BeExactly $want
     }
@@ -313,6 +313,24 @@ Describe "Poker test cases" {
             "2H 3H 4H 5H 6H",
             "4D AD 3D 2D 5D")
         $want = @("2H 3H 4H 5H 6H")
+    
+        $got | Should -BeExactly $want
+    }
+
+    It "winning high card hand also has the lowest card" {
+        $got  = Get-BestHand -Hands @(
+            "2S 5H 6S 8D 7H",
+            "3S 4D 6D 8C 7S")
+        $want = @("2S 5H 6S 8D 7H")
+    
+        $got | Should -BeExactly $want
+    }
+
+    It "both hands have the same pair, high card wins" {
+        $got  = Get-BestHand -Hands @(
+            "4H 4S AH JC 3D",
+            "4C 4D AS 5D 6C")
+        $want = @("4H 4S AH JC 3D")
     
         $got | Should -BeExactly $want
     }

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -13,7 +13,7 @@
       ".meta/PythagoreanTriplet.example.ps1"
     ]
   },
-  "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
+  "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the triplet.",
   "source": "Problem 9 at Project Euler",
   "source_url": "https://projecteuler.net/problem=9"
 }

--- a/exercises/practice/rotational-cipher/.meta/tests.toml
+++ b/exercises/practice/rotational-cipher/.meta/tests.toml
@@ -24,6 +24,9 @@ description = "rotate m by 13"
 [19f9eb78-e2ad-4da4-8fe3-9291d47c1709]
 description = "rotate n by 13 with wrap around alphabet"
 
+[a116aef4-225b-4da9-884f-e8023ca6408a]
+description = "rotate capital letters"
+
 [71b541bb-819c-4dc6-a9c3-132ef9bb737b]
 description = "rotate spaces"
 

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -24,6 +24,9 @@ description = "slices of two overlap"
 [8e17148d-ba0a-4007-a07f-d7f87015d84c]
 description = "slices can include duplicates"
 
+[bd5b085e-f612-4f81-97a8-6314258278b0]
+description = "slices of a long series"
+
 [6d235d85-46cf-4fae-9955-14b6efef27cd]
 description = "slice length is too large"
 

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -15,5 +15,5 @@
   },
   "blurb": "Given the size, return a square matrix of numbers in spiral order.",
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
-  "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"
+  "source_url": "https://web.archive.org/web/20230607064729/https://old.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"
 }

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,5 +1,7 @@
 {
-  "authors": ["glaxxie"],
+  "authors": [
+    "glaxxie"
+  ],
   "files": {
     "solution": [
       "Strain.ps1"
@@ -13,5 +15,5 @@
   },
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "source": "Conversation with James Edward Gray II",
-  "source_url": "https://twitter.com/jeg2"
+  "source_url": "http://graysoftinc.com/"
 }

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -15,5 +15,5 @@
   },
   "blurb": "Take input text and output it transposed.",
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
-  "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"
+  "source_url": "https://web.archive.org/web/20230630051421/https://old.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text/"
 }


### PR DESCRIPTION
Despite updating `tests.toml` file for many exercises, only tests in : Anagram, Custom Set, Dnd Character and Poker got updated.

The rest other exercises' test suites got flagged but not updated because they are already got included or updated correctly prior to this.

The reason it happened is because in the process of implementing those exercise, I not only look at the toml file but also looked at the test suite from a more well developed track (python in this case), and inadvertently created the test suite that was ahead of the toml file. 