### PR TITLE
Fix bug in example and tests for Baffling Birthdays

### DIFF
--- a/exercises/practice/baffling-birthdays/.meta/BafflingBirthdays.example.ps1
+++ b/exercises/practice/baffling-birthdays/.meta/BafflingBirthdays.example.ps1
@@ -19,16 +19,9 @@ Function Invoke-BafflingBirthdays {
     $runs = 5000
     $count = 0
     for ($i = 0; $i -lt $runs; $i++) {
-        $birthdays = Get-RandomBirthdates -People $People
-        $count += Test-SharedBirthday -Birthdates $birthdays
+        $count += Test-SharedBirthday -Birthdates (Get-RandomBirthdates -People $People)
     }
     $count * 100.00 / $runs
-}
-
-Function Get-RandomBirthdate([int]$Year) {
-    $month = Get-Random -Minimum 1 -Maximum (12 + 1)
-    $day   = Get-Random -Minimum 1 -Maximum (([DateTime]::DaysInMonth($Year, $month)) + 1)
-    [datetime]::New($Year, $month, $day)
 }
 
 Function Get-RandomBirthdates {
@@ -47,9 +40,8 @@ Function Get-RandomBirthdates {
         $year = Get-Random -Minimum 1900 -Maximum ((Get-Date).Year + 1)
     } until (-not [DateTime]::IsLeapYear($year))
 
-    for ($i = 0; $i -lt $People; $i++) {
-        Get-RandomBirthdate $year
-    }
+    Get-Random -Minimum 0 -Maximum 365 -Count $People |
+        ForEach-Object { [DateTime]::new($year, 1, 1).AddDays($_) }
 }
 
 Function Test-SharedBirthday {
@@ -64,7 +56,7 @@ Function Test-SharedBirthday {
     Param(
         [DateTime[]]$Birthdates
     )
-    for ($i = 0; $i -lt $Birthdates.Count; $i++) {
+    for ($i = 0; $i -lt $Birthdates.Count - 1; $i++) {
         for ($j = $i+1; $j -lt $Birthdates.Count; $j++) {
             if ($Birthdates[$i].DayOfYear -eq $Birthdates[$j].DayOfYear) {
                 return $true

--- a/exercises/practice/baffling-birthdays/.meta/BafflingBirthdays.example.ps1
+++ b/exercises/practice/baffling-birthdays/.meta/BafflingBirthdays.example.ps1
@@ -11,6 +11,9 @@ Function Invoke-BafflingBirthdays {
 
     .PARAMETER People
     Number of people in the group.
+
+    .NOTES
+    Consider doing 5000 runs of the test for optimal result for 2% tolerance.
     #>
     [CmdletBinding()]
     Param(

--- a/exercises/practice/baffling-birthdays/.meta/BafflingBirthdays.example.ps1
+++ b/exercises/practice/baffling-birthdays/.meta/BafflingBirthdays.example.ps1
@@ -16,13 +16,13 @@ Function Invoke-BafflingBirthdays {
     Param(
         [int]$People
     )
-    $runs = 1000
+    $runs = 5000
     $count = 0
     for ($i = 0; $i -lt $runs; $i++) {
         $birthdays = Get-RandomBirthdates -People $People
         $count += Test-SharedBirthday -Birthdates $birthdays
     }
-    $count /  100.00
+    $count * 100.00 / $runs
 }
 
 Function Get-RandomBirthdate([int]$Year) {

--- a/exercises/practice/baffling-birthdays/BafflingBirthdays.ps1
+++ b/exercises/practice/baffling-birthdays/BafflingBirthdays.ps1
@@ -11,6 +11,9 @@ Function Invoke-BafflingBirthdays {
 
     .PARAMETER People
     Number of people in the group.
+
+    .NOTES
+    Consider doing 5000 runs of the test for optimal result for 2% tolerance.
     #>
     [CmdletBinding()]
     Param(

--- a/exercises/practice/baffling-birthdays/BafflingBirthdays.tests.ps1
+++ b/exercises/practice/baffling-birthdays/BafflingBirthdays.tests.ps1
@@ -139,9 +139,9 @@ Describe "BafflingBirthdays test cases" {
 
     Context "estimated probability" {
         BeforeAll {
-            $tolerance = 1
+            $tolerance = 2
             function Test-Probability($Probability, $Expected, $Tolerance) {
-                ($Probability -ge $Expected - $Tolerance) -or ($Probability -le $Expected + $Tolerance)
+                ($Probability -ge $Expected - $Tolerance) -and ($Probability -le $Expected + $Tolerance)
             }
         }
 


### PR DESCRIPTION
This is the minimum change needed to get the example and tests to work. See [this discussion](https://forum.exercism.org/t/bug-in-baffling-birthdays-tests/17668) for details. However, the example is very slow. On my PC, it takes about 28 seconds to complete.