### PR TITLE
Corrected typo in FlattenArray.ps1

### DIFF
--- a/exercises/practice/flatten-array/.meta/FlattenArray.example.ps1
+++ b/exercises/practice/flatten-array/.meta/FlattenArray.example.ps1
@@ -1,10 +1,10 @@
 Function Invoke-FlattenArray() {
     <#
     .SYNOPSIS
-    Given an array, flatten it and keep all values except null.
+    Take a nested array and return a single flattened array with all values except null.
 
     .DESCRIPTION
-    Take a nested array and return a single flattened array with all values except null.
+    Given an array, flatten it and keep all values except null.
 
     .PARAMETER Array
     The nested array to be flattened.

--- a/exercises/practice/flatten-array/.meta/FlattenArray.example.ps1
+++ b/exercises/practice/flatten-array/.meta/FlattenArray.example.ps1
@@ -1,13 +1,13 @@
 Function Invoke-FlattenArray() {
     <#
     .SYNOPSIS
-    Given an array, flatten it and keep all values execept null.
+    Given an array, flatten it and keep all values except null.
 
     .DESCRIPTION
     Take a nested array and return a single flattened array with all values except null.
 
     .PARAMETER Array
-    The nested array to be flatten.
+    The nested array to be flattened.
 
     .EXAMPLE
     Invoke-FlattenArray -Array @(1, @(2, 3, $null, 4), @($null), 5)

--- a/exercises/practice/flatten-array/FlattenArray.ps1
+++ b/exercises/practice/flatten-array/FlattenArray.ps1
@@ -4,7 +4,7 @@ Function Invoke-FlattenArray() {
     Take a nested array and return a single flattened array with all values except null.
 
     .DESCRIPTION
-    Given an array, flatten it and keep all values execept null.
+    Given an array, flatten it and keep all values except null.
 
     .PARAMETER Array
     The nested array to be flatten.

--- a/exercises/practice/flatten-array/FlattenArray.ps1
+++ b/exercises/practice/flatten-array/FlattenArray.ps1
@@ -7,7 +7,7 @@ Function Invoke-FlattenArray() {
     Given an array, flatten it and keep all values except null.
 
     .PARAMETER Array
-    The nested array to be flatten.
+    The nested array to be flattened.
 
     .EXAMPLE
     Invoke-FlattenArray -Array @(1, @(2, 3, $null, 4), @($null), 5)


### PR DESCRIPTION
Typo correction of _except_ in the Description in the FlattenArray.ps1

Fixes #412 
