### PR TITLE
[no important files changed] Fix REST API tests

### DIFF
--- a/exercises/practice/rest-api/RestApi.tests.ps1
+++ b/exercises/practice/rest-api/RestApi.tests.ps1
@@ -2,30 +2,40 @@ BeforeAll {
     . "./RestApi.ps1"
 
     Function Test-ApiResult([object]$got, [object]$want, [string]$path = "expected") {
+        <#
+        .SYNOPSIS
+        Test the result returned from a REST API call to make sure that it matches the expected value.
+
+        .DESCRIPTION
+        Recursively test the result returned from a REST API call against the expected value:
+
+        - For a hash table:
+          - Make sure that the keys match
+          - Recursively check that each value matches
+        - For an array:
+          - Make sure that the number of values match
+          - Recursively check that each value matches
+        - For a simple value, make sure that the value matches
+        #>
         if ($want -is [hashtable]) {
-            # Make sure keys are the same
             $gotKeys = $got.Keys | Sort-Object
             $wantKeys = $want.Keys | Sort-Object
             $gotKeys | Should -BeExactly $wantKeys -Because "those are the expected keys for $path"
 
-            # Make sure values are the same
             foreach ($entry in $want.GetEnumerator()) {
                 Test-ApiResult $got[$entry.Key] $entry.Value "$path[`"$($entry.Key)`"]"
             }
         }
         elseif ($want -is [array]) {
-            # Make number of values is the same
             $gotCount = $got.Count
             $wantCount = $want.Count
             $gotCount | Should -BeExactly $wantCount -Because "that is the expected number of $path values"
 
-            # Make sure values are the same
             for ($i = 0; $i -lt $wantCount; $i++) {
                 Test-ApiResult $got[$i] $want[$i] "$path[$i]"
             }
         }
         else {
-            # Make sure value is the same
             $got | Should -BeExactly $want -Because "that is the expected value for $path"
         }
     }

--- a/exercises/practice/rest-api/RestApi.tests.ps1
+++ b/exercises/practice/rest-api/RestApi.tests.ps1
@@ -2,6 +2,7 @@ BeforeAll {
     . "./RestApi.ps1"
 
     Function Test-ApiResult([object]$got, [object]$want, [string[]]$path = $null) {
+        $path = $path ?? @()
         $basePath = $path -join "."
         if ($want -is [hashtable]) {
             # Make sure keys are the same

--- a/exercises/practice/rest-api/RestApi.tests.ps1
+++ b/exercises/practice/rest-api/RestApi.tests.ps1
@@ -1,34 +1,32 @@
 BeforeAll {
     . "./RestApi.ps1"
 
-    Function Test-ApiResult([object]$got, [object]$want, [string[]]$path = $null) {
-        $path = $path ?? @()
-        $basePath = $path -join "."
+    Function Test-ApiResult([object]$got, [object]$want, [string]$path = "expected") {
         if ($want -is [hashtable]) {
             # Make sure keys are the same
             $gotKeys = $got.Keys | Sort-Object
             $wantKeys = $want.Keys | Sort-Object
-            $gotKeys | Should -BeExactly $wantKeys -Because "$basePath keys"
+            $gotKeys | Should -BeExactly $wantKeys -Because "those are the expected keys for $path"
 
             # Make sure values are the same
             foreach ($entry in $want.GetEnumerator()) {
-                Test-ApiResult $got[$entry.Key] $entry.Value ($path + $entry.Key)
+                Test-ApiResult $got[$entry.Key] $entry.Value "$path[`"$($entry.Key)`"]"
             }
         }
         elseif ($want -is [array]) {
             # Make number of values is the same
             $gotCount = $got.Count
             $wantCount = $want.Count
-            $gotCount | Should -BeExactly $wantCount -Because "$basePath value count"
+            $gotCount | Should -BeExactly $wantCount -Because "that is the expected number of $path values"
 
             # Make sure values are the same
             for ($i = 0; $i -lt $wantCount; $i++) {
-                Test-ApiResult $got[$i] $want[$i] ($path + "[$i]")
+                Test-ApiResult $got[$i] $want[$i] "$path[$i]"
             }
         }
         else {
             # Make sure value is the same
-            $got | Should -BeExactly $want -Because $basePath
+            $got | Should -BeExactly $want -Because "that is the expected value for $path"
         }
     }
 }


### PR DESCRIPTION
I ran the tests for the example code 100 times with this script, and it passed every time:
```bash
#!/bin/bash
numIter=${1:-100}
pass=1
for i in $(seq 1 $numIter)
do
    echo
    echo "*** Iteration $i ***"
    pwsh -Command Invoke-Pester | tee output.txt
    if ! (tail -n 1 output.txt | grep -sq "Failed: 0,")
    then
        echo "FAILED!"
        pass=0
        break
    fi
done

rm -f output.txt
if [ $pass -ne 0 ]
then
    echo "PASSED"
fi
```

I also forced some failures and the tests failed. Here are examples of error messages where I deliberately changed the expected values in the tests:

- Expected exactly @('balance', 'name', 'owed_bye', 'owes'), because those are the expected keys for expected["users"][1], but got @('balance', 'name', 'owed_by', 'owes').
- Expected exactly 3, because that is the expected number of expected["users"] values, but got 2.
- Expected exactly 1, because that is the expected value for expected["users"][0]["balance"], but got 0.
