### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/binary-search-tree/.docs/instructions.append.md
+++ b/exercises/practice/binary-search-tree/.docs/instructions.append.md
@@ -1,4 +1,7 @@
+# Instructions append
+
 ## Printing Tree
+
 This exercise has some predefined class methods to help printing out the tree in a nice format.
 Its main purpose is to help debugging and provide extra clarity.
 If you implement the rest of the class correctly it should print out the tree for you.

--- a/exercises/practice/error-handling/.docs/instructions.append.md
+++ b/exercises/practice/error-handling/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# PowerShell track
+# Instructions append
+
+## PowerShell track
 
 The functions in the exercise are short and not supposed to be complicated.
 

--- a/exercises/practice/grep/.docs/instructions.append.md
+++ b/exercises/practice/grep/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Powershell Track
 
 ### Flags change
@@ -20,4 +22,5 @@ This exercise will provide 3 required text files: `iliad.txt`, `midsummer-night.
 
 ### Cmdlet
 
-Powershell does have a cmdlet similar to `grep` called `Select-String`, and you could read more about it [here](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/select-string) if you are interested. You should not use `Select-String` for this exercise at any point.
+Powershell does have a cmdlet similar to `grep` called `Select-String`, and you could read more about it [here](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/select-string) if you are interested.
+You should not use `Select-String` for this exercise at any point.

--- a/exercises/practice/hangman/.docs/instructions.append.md
+++ b/exercises/practice/hangman/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Powershell Track
 
 This exercise has been adapted to not required any third party library regarding functional reactive programming so it can work with Powershell. 

--- a/exercises/practice/micro-blog/.docs/instructions.append.md
+++ b/exercises/practice/micro-blog/.docs/instructions.append.md
@@ -1,2 +1,5 @@
+# Instructions append
+
 ## Powershell Resource
+
 Powershell utilize a lot of built in .NET classes, for this exercise you should consider taking a look at this [page](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.stringinfo) to work with the API.

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,4 +1,7 @@
-# About Enum
+# Instructions append
+
+## About Enum
+
 Use Enum values to show the 4 cardinal directions: NORTH, EAST, SOUTH, WEST.
 
 To know more about Enum in powershell please check out [Enum module.](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_enum)

--- a/exercises/practice/state-of-tic-tac-toe/.docs/instructions.append.md
+++ b/exercises/practice/state-of-tic-tac-toe/.docs/instructions.append.md
@@ -1,4 +1,7 @@
-# About Enum
+# Instructions append
+
+## About Enum
+
 Use Enum values to show the game state, e.g. ONGOING
 
 To know more about Enum in powershell please check out [Enum module.](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_enum)

--- a/exercises/practice/sublist/.docs/instructions.append.md
+++ b/exercises/practice/sublist/.docs/instructions.append.md
@@ -1,4 +1,7 @@
-# About Enum
+# Instructions append
+
+## About Enum
+
 Use Enum values to show relationship between two list, e.g. SUBLIST
 
 To know more about Enum in powershell please check out [Enum module.](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_enum)

--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -1,4 +1,7 @@
-# About Enum
+# Instructions append
+
+## About Enum
+
 The enum statement allows you to create a strongly typed set of labels.
 You can use that enumeration in the code without having to parse or check for spelling errors.
 


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.